### PR TITLE
docs: add bilingual changelog and readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+Todos los cambios notables de este proyecto se documentarán en este archivo.
+
+El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/) y este proyecto intenta adherirse a [Semantic Versioning](https://semver.org/lang/es/).
+
+## [Sin publicar]
+### Añadido
+- Espacio reservado para próximos cambios.
+
+## [0.3.0] - 2025-09-29
+### Añadido
+- Registro en consola con formato enriquecido y estadísticas agregadas para todas las reservas.
+- Filtro opcional por clase de reserva al generar el log.
+
+### Corregido
+- Ajuste en la presentación de las reservas para evitar desalineaciones en la salida de consola.
+
+## [0.2.0] - 2025-09-29
+### Añadido
+- Cuadro de diálogo con control numérico para definir cuántas reservas capturar en una sesión.
+- Comentarios aclaratorios en el código para facilitar el mantenimiento.
+
+### Eliminado
+- Importaciones innecesarias detectadas durante la revisión.
+
+## [0.1.0] - 2025-09-28
+### Añadido
+- Enumeraciones de campos y clases de reserva para estandarizar la estructura del archivo.
+- Creación validada de archivos de salida con encabezados configurables.
+- Captura asistida de datos de pasajeros y escritura en `reservas.txt`.
+- Documentación inicial y configuración de `.gitignore`.
+
+> Nota: Genera etiquetas (tags) en el repositorio para activar los enlaces de comparación entre versiones.

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the project aims to follow [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+### Added
+- Placeholder for upcoming changes.
+
+## [0.3.0] - 2025-09-29
+### Added
+- Rich console log with aggregated statistics for every reservation.
+- Optional class-based filtering when rendering the log.
+
+### Fixed
+- Adjusted the reservation output to avoid misalignment in the console view.
+
+## [0.2.0] - 2025-09-29
+### Added
+- Numeric spinner dialog to define how many reservations to capture per session.
+- Clarifying comments in the codebase to improve maintainability.
+
+### Removed
+- Unused imports discovered during review.
+
+## [0.1.0] - 2025-09-28
+### Added
+- Field and class enumerations to standardize the reservation file structure.
+- Validated creation of output files with configurable headers.
+- Assisted data capture for passengers and persistence to `reservas.txt`.
+- Initial documentation and `.gitignore` setup.
+
+> Note: Create Git tags in the repository to enable comparison links between versions.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,81 @@
-prueba
+# Gestor de Reservas Aéreas
+
+Este repositorio contiene una aplicación de consola escrita en Java que permite crear y gestionar un registro básico de reservas aéreas. El flujo principal se centra en la generación de un archivo CSV (`reservas.txt`), la recopilación de datos mediante cuadros de diálogo y la presentación de un resumen formateado con estadísticas.
+
+## Características principales
+
+- Creación de archivos de reservas con validación de nombre y permisos.
+- Estructura configurable de campos mediante enumeraciones (`ReservationFields`).
+- Captura asistida de datos con interfaces emergentes (`JOptionPane`).
+- Registro interactivo para determinar cuántas reservas capturar en una sesión.
+- Visualización formateada de reservas en consola con encabezados y emojis.
+- Estadísticas resumidas, incluido el filtrado opcional por clase (`ReservationClass`).
+
+## Requisitos previos
+
+- Java Development Kit (JDK) 17 o superior.
+- Sistema operativo con soporte para la interfaz gráfica de Java (Swing).
+
+## Configuración del proyecto
+
+1. Clona el repositorio y entra en la carpeta principal:
+   ```bash
+   git clone <url-del-repositorio>
+   cd Tarea-01
+   ```
+2. Accede al módulo con el código fuente:
+   ```bash
+   cd Tarea-01
+   ```
+3. Asegúrate de tener el JDK instalado y configurado en la variable de entorno `JAVA_HOME`.
+
+## Ejecución
+
+Desde la carpeta `Tarea-01/` que contiene el código fuente (es decir, `Tarea-01/Tarea-01` respecto al repositorio):
+
+```bash
+javac -d out src/*.java
+java -cp out Main
+```
+
+Al iniciar, la aplicación solicitará:
+
+1. El número de registros a crear.
+2. El número de asiento, nombre del pasajero y clase para cada reserva.
+3. Opcionalmente, el destino si se inicializa `ReservationAll` con el modo de cuatro campos.
+
+El resultado se guarda en `reservas.txt` y se muestra un log formateado en la consola.
+
+## Estructura del repositorio
+
+```text
+Tarea-01/
+├── LICENSE
+├── README.md
+├── README_EN.md
+├── CHANGELOG.md
+├── CHANGELOG_EN.md
+└── Tarea-01/
+    └── src/
+        ├── Main.java
+        ├── ReservationAll.java
+        ├── ReservationClass.java
+        └── ReservationFields.java
+```
+
+## Flujo de trabajo recomendado
+
+- **Ramas**: utiliza ramas de características (`feature/`), correcciones (`hotfix/`) y ramas de integración (`develop`, `main`).
+- **Commits**: emplea mensajes descriptivos orientados a la acción, por ejemplo `Added: Soporte para destinos`.
+- **Pull Requests**: describe claramente el alcance, pruebas realizadas y cualquier consideración adicional.
+
+## Contribuir
+
+1. Crea un fork del repositorio.
+2. Genera una rama de trabajo descriptiva.
+3. Implementa los cambios con pruebas locales.
+4. Envía un pull request explicando el motivo y el impacto.
+
+## Licencia
+
+Este proyecto está disponible bajo la licencia MIT. Consulta el archivo [`LICENSE`](LICENSE) para más información.

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,81 @@
+# Airline Reservation Manager
+
+This repository hosts a console-based Java application that creates and manages a lightweight registry of airline reservations. The main workflow generates a CSV file (`reservas.txt`), gathers passenger data through dialog windows, and prints a formatted summary with helpful statistics.
+
+## Key Features
+
+- Reservation file creation with name validation and permission handling.
+- Configurable field structure via enumerations (`ReservationFields`).
+- Assisted data capture using Swing dialog boxes (`JOptionPane`).
+- Interactive prompt to decide how many reservations to capture per session.
+- Console log formatted with headers and emojis for readability.
+- Summary statistics with optional filtering by reservation class (`ReservationClass`).
+
+## Prerequisites
+
+- Java Development Kit (JDK) 17 or later.
+- Operating system capable of running Java Swing interfaces.
+
+## Project Setup
+
+1. Clone the repository and enter the root folder:
+   ```bash
+   git clone <repository-url>
+   cd Tarea-01
+   ```
+2. Move into the module that contains the source code:
+   ```bash
+   cd Tarea-01
+   ```
+3. Ensure the JDK is installed and that the `JAVA_HOME` environment variable is configured.
+
+## Running the project
+
+From the `Tarea-01/` folder that hosts the source code (i.e., `Tarea-01/Tarea-01` relative to the repository):
+
+```bash
+javac -d out src/*.java
+java -cp out Main
+```
+
+When launched, the application will ask for:
+
+1. The number of reservation records to create.
+2. Seat number, passenger name, and class for each reservation.
+3. Optionally, the destination if `ReservationAll` is initialized with the four-field mode.
+
+Results are stored in `reservas.txt`, and a formatted log is printed to the console.
+
+## Repository structure
+
+```text
+Tarea-01/
+├── LICENSE
+├── README.md
+├── README_EN.md
+├── CHANGELOG.md
+├── CHANGELOG_EN.md
+└── Tarea-01/
+    └── src/
+        ├── Main.java
+        ├── ReservationAll.java
+        ├── ReservationClass.java
+        └── ReservationFields.java
+```
+
+## Recommended workflow
+
+- **Branches**: use feature (`feature/`), hotfix (`hotfix/`), and integration (`develop`, `main`) branches.
+- **Commits**: keep action-oriented messages such as `Added: Support for destinations`.
+- **Pull Requests**: document scope, local testing, and any noteworthy considerations.
+
+## Contributing
+
+1. Fork the repository.
+2. Create a descriptive working branch.
+3. Implement the changes and run local validations.
+4. Open a pull request detailing the motivation and impact.
+
+## License
+
+This project is distributed under the MIT License. Refer to the [`LICENSE`](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- add a Spanish README with project setup, execution, and contribution guidelines
- provide an English translation of the README for international contributors
- document the project history with Spanish and English changelog files following Keep a Changelog conventions

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68dc2a6a66c48320809e91a3610accfc