### PR TITLE
Restore original main workflow and sync documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Todos los cambios notables de este proyecto se documentarán en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/) y este proyecto intenta adherirse a [Semantic Versioning](https://semver.org/lang/es/).
 
 ## [Unreleased]
+### Cambiado
+- Mejora de la legibilidad del código mediante JavaDoc exhaustivo y reorganización de ejemplos de uso.
+- Actualización de la documentación pública (README y guía completa) para reflejar los nuevos flujos.
 
 ## [3.0.0] - 2025-10-04
 ### Añadido

--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Improved code readability with comprehensive JavaDoc and reorganized usage examples.
+- Updated public documentation (README files and full guide) to reflect the current workflows.
 
 ## [3.0.0] - 2025-10-04
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Gestor de Reservas Aéreas
 
-Este repositorio contiene una aplicación de consola escrita en Java que permite crear y gestionar un registro básico de reservas aéreas. El flujo principal se centra en la generación de un archivo CSV (`reservas.txt`), la recopilación de datos mediante cuadros de diálogo y la presentación de un resumen formateado con estadísticas.
+Este repositorio contiene una aplicación en Java que permite crear y gestionar un registro básico de reservas aéreas. El flujo principal se centra en la generación de archivos CSV, la recopilación de datos mediante cuadros de diálogo (`JOptionPane`) y la presentación de un resumen formateado con estadísticas.
 
 ## Características principales
 
-- Creación de archivos de reservas con validación de nombre y permisos.
+- Creación de archivos de reservas con validación de nombre, permisos y estructura.
 - Estructura configurable de campos mediante enumeraciones (`Reservation.ReservationFields`).
 - Captura asistida de datos con interfaces emergentes (`JOptionPane`).
 - Registro interactivo para determinar cuántas reservas capturar en una sesión.
-- Visualización formateada de reservas en consola con encabezados y emojis.
+- Visualización formateada de reservas en consola con encabezados, emojis y estadísticas filtradas.
 - Estadísticas resumidas, incluido el filtrado opcional por clase (`Reservation.ReservationClass`).
 
 ## Requisitos previos
@@ -27,24 +27,28 @@ Este repositorio contiene una aplicación de consola escrita en Java que permite
    ```bash
    cd Tarea-01
    ```
-3. Asegúrate de tener el JDK instalado y configurado en la variable de entorno `JAVA_HOME`.
+3. Crea la carpeta de salida y compila los archivos Java:
+   ```bash
+   mkdir -p out
+   javac -d out $(find src -name "*.java")
+   ```
+4. Asegúrate de tener el JDK instalado y configurado en la variable de entorno `JAVA_HOME`.
 
 ## Ejecución
 
 Desde la carpeta `Tarea-01/` que contiene el código fuente (es decir, `Tarea-01/Tarea-01` respecto al repositorio):
 
 ```bash
-javac -d out src/*.java
 java -cp out Reservation.Main
 ```
 
-Al iniciar, la aplicación solicitará:
+Al iniciar, la aplicación reproduce los tres ejercicios del proyecto:
 
-1. El número de registros a crear.
-2. El número de asiento, nombre del pasajero y clase para cada reserva.
-3. Opcionalmente, el destino si se inicializa `Reservation.ReservationAll` con el modo de cuatro campos.
+1. (Opcional) Creación de un archivo base de reservas con tres campos.
+2. Creación del maestro de reservas, captura guiada mediante `JOptionPane` y distribución por destino.
+3. Validación de un archivo con errores para observar cómo se registran las incidencias.
 
-El resultado se guarda en `reservas.txt` y se muestra un log formateado en la consola.
+Los resultados se guardan en `reservas_maestro.txt`, se crean archivos por destino y se muestra un log formateado en la consola. Si existe el archivo `reservas_maestro_con_errores.txt` se demostrará además el flujo de validación masiva.
 
 ## Estructura del repositorio
 
@@ -55,12 +59,18 @@ Tarea-01/
 ├── README_EN.md
 ├── CHANGELOG.md
 ├── CHANGELOG_EN.md
+├── docs/
+│   └── DOCUMENTACION_PROYECTO.md
 └── Tarea-01/
     └── src/
-        ├── Reservation.Main.java
-        ├── Reservation.ReservationAll.java
-        ├── Reservation.ReservationClass.java
-        └── Reservation.ReservationFields.java
+        ├── Reservation/
+        │   ├── Destinations.java
+        │   ├── Main.java
+        │   ├── ReservationAll.java
+        │   ├── ReservationClass.java
+        │   └── ReservationFields.java
+        └── Utils/
+            └── Utils.java
 ```
 
 ## Flujo de trabajo recomendado
@@ -69,12 +79,9 @@ Tarea-01/
 - **Commits**: emplea mensajes descriptivos orientados a la acción, por ejemplo `Added: Soporte para destinos`.
 - **Pull Requests**: describe claramente el alcance, pruebas realizadas y cualquier consideración adicional.
 
-## Contribuir
+## Documentación ampliada
 
-1. Crea un fork del repositorio.
-2. Genera una rama de trabajo descriptiva.
-3. Implementa los cambios con pruebas locales.
-4. Envía un pull request explicando el motivo y el impacto.
+La guía completa del proyecto, con explicación detallada de flujos, validaciones y ejemplos, se encuentra en [`docs/DOCUMENTACION_PROYECTO.md`](docs/DOCUMENTACION_PROYECTO.md).
 
 ## Licencia
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,14 +1,14 @@
 # Airline Reservation Manager
 
-This repository hosts a console-based Java application that creates and manages a lightweight registry of airline reservations. The main workflow generates a CSV file (`reservas.txt`), gathers passenger data through dialog windows, and prints a formatted summary with helpful statistics.
+This repository hosts a Java application that creates and manages a lightweight registry of airline reservations. The main workflow generates CSV files, gathers passenger data through dialog windows (`JOptionPane`), and prints a formatted summary with helpful statistics.
 
 ## Key Features
 
-- Reservation file creation with name validation and permission handling.
+- Reservation file creation with name, permission, and structure validation.
 - Configurable field structure via enumerations (`Reservation.ReservationFields`).
 - Assisted data capture using Swing dialog boxes (`JOptionPane`).
 - Interactive prompt to decide how many reservations to capture per session.
-- Console log formatted with headers and emojis for readability.
+- Console log formatted with headers, emojis, and optional filtered statistics.
 - Summary statistics with optional filtering by reservation class (`Reservation.ReservationClass`).
 
 ## Prerequisites
@@ -27,24 +27,28 @@ This repository hosts a console-based Java application that creates and manages 
    ```bash
    cd Tarea-01
    ```
-3. Ensure the JDK is installed and that the `JAVA_HOME` environment variable is configured.
+3. Create the output directory and compile the Java sources:
+   ```bash
+   mkdir -p out
+   javac -d out $(find src -name "*.java")
+   ```
+4. Ensure the JDK is installed and that the `JAVA_HOME` environment variable is configured.
 
 ## Running the project
 
 From the `Tarea-01/` folder that hosts the source code (i.e., `Tarea-01/Tarea-01` relative to the repository):
 
 ```bash
-javac -d out src/*.java
 java -cp out Reservation.Main
 ```
 
-When launched, the application will ask for:
+When launched, the program replays the three exercises packaged with the project:
 
-1. The number of reservation records to create.
-2. Seat number, passenger name, and class for each reservation.
-3. Optionally, the destination if `Reservation.ReservationAll` is initialized with the four-field mode.
+1. (Optional) Create a base reservation file with three fields.
+2. Build the master reservation file, capture passenger data via `JOptionPane`, and split the records by destination.
+3. Validate an error-prone file to review how issues are reported.
 
-Results are stored in `reservas.txt`, and a formatted log is printed to the console.
+Results are stored in `reservas_maestro.txt`, destination files are generated, and a formatted log is printed to the console. When `reservas_maestro_con_errores.txt` is present, the batch-validation flow is also showcased.
 
 ## Repository structure
 
@@ -55,12 +59,18 @@ Tarea-01/
 ├── README_EN.md
 ├── CHANGELOG.md
 ├── CHANGELOG_EN.md
+├── docs/
+│   └── DOCUMENTACION_PROYECTO.md
 └── Tarea-01/
     └── src/
-        ├── Reservation.Main.java
-        ├── Reservation.ReservationAll.java
-        ├── Reservation.ReservationClass.java
-        └── Reservation.ReservationFields.java
+        ├── Reservation/
+        │   ├── Destinations.java
+        │   ├── Main.java
+        │   ├── ReservationAll.java
+        │   ├── ReservationClass.java
+        │   └── ReservationFields.java
+        └── Utils/
+            └── Utils.java
 ```
 
 ## Recommended workflow
@@ -69,12 +79,9 @@ Tarea-01/
 - **Commits**: keep action-oriented messages such as `Added: Support for destinations`.
 - **Pull Requests**: document scope, local testing, and any noteworthy considerations.
 
-## Contributing
+## Extended documentation
 
-1. Fork the repository.
-2. Create a descriptive working branch.
-3. Implement the changes and run local validations.
-4. Open a pull request detailing the motivation and impact.
+The complete project guide with detailed flows, validations, and examples is available at [`docs/DOCUMENTACION_PROYECTO.md`](docs/DOCUMENTACION_PROYECTO.md).
 
 ## License
 

--- a/Tarea-01/src/Reservation/Destinations.java
+++ b/Tarea-01/src/Reservation/Destinations.java
@@ -1,5 +1,9 @@
 package Reservation;
 
+/**
+ * Listado de destinos soportados por el sistema. Se utiliza para estandarizar la escritura en los
+ * archivos CSV y evitar discrepancias en la clasificación por país.
+ */
 public enum Destinations {
     PARIS,
     LONDRES,

--- a/Tarea-01/src/Reservation/Main.java
+++ b/Tarea-01/src/Reservation/Main.java
@@ -2,9 +2,26 @@ package Reservation;
 
 import java.io.File;
 import java.io.IOException;
+
 import Utils.Utils;
 
+/**
+ * Punto de entrada de la aplicación de reservas. Mantiene el flujo original de ejercicios
+ * solicitados para la práctica, con el fin de que pueda revisarse o reproducirse sin sorpresas.
+ */
 public class Main {
+
+    /**
+     * Ejecuta secuencialmente los tres ejercicios planteados en la práctica:
+     * <ol>
+     *     <li>Creación del archivo base de reservas (comentado para conservar la versión inicial).</li>
+     *     <li>Generación del archivo maestro, distribución por destino y filtrado por clase.</li>
+     *     <li>Validación de un archivo con datos erróneos utilizando las utilidades del proyecto.</li>
+     * </ol>
+     *
+     * @param args argumentos de línea de comandos (no utilizados).
+     * @throws IOException si se produce un problema al crear o manipular los archivos requeridos.
+     */
     public static void main(String[] args) throws IOException {
 //        ReservationAll reservePt1 = new ReservationAll("reservas.txt");
 //        File file1 = reservePt1.createFile();  // guardar referencia al archivo creado
@@ -29,7 +46,7 @@ public class Main {
         );
         reservePt2.pickHowManyRegisters();
         reservePt2.createandFillFileByDestination(ReservationFields.DESTINATION);
-        reservePt2.logguer(Reservation.ReservationClass.BUSINESS);
+        reservePt2.logguer(ReservationClass.BUSINESS);
         ReservationAll.showReservationsByCountry(Destinations.TOKIO);
 
         ReservationAll reservePt3 = new ReservationAll(false, "reservas_maestro_con_errores.txt");

--- a/Tarea-01/src/Reservation/ReservationAll.java
+++ b/Tarea-01/src/Reservation/ReservationAll.java
@@ -8,25 +8,50 @@ import java.util.*;
 import static Utils.Utils.*;
 import static java.util.Arrays.stream;
 
+/**
+ * Gestiona la creación y explotación de archivos de reservas. Esta clase ofrece utilidades para
+ * generar ficheros CSV, capturar información mediante cuadros de diálogo y realizar operaciones de
+ * reporte o particionado por destino.
+ */
 public class ReservationAll {
     private final String fileName;
     private boolean has4Fields = false;
 
-    // ------------- CONSTRUCTORS ----------------
+    /**
+     * Crea una instancia asociada a un archivo de reservas que se inicializa con los campos
+     * estándar (número de asiento, nombre y clase).
+     *
+     * @param fileName nombre del archivo que se gestionará.
+     */
     public ReservationAll(String fileName) {
         this.fileName = fileName;
     }
 
+    /**
+     * Constructor sin argumentos deshabilitado para evitar instancias incompletas.
+     */
     public ReservationAll() {
         throw new UnsupportedOperationException("Introduce los campos necesarios y el nombre del archivo");
     }
 
+    /**
+     * Crea una instancia configurando explícitamente si se trabajará con un cuarto campo (destino).
+     *
+     * @param has4Fields {@code true} si el archivo gestionará también destinos.
+     * @param fileName   nombre del archivo que se gestionará.
+     */
     public ReservationAll(boolean has4Fields, String fileName) {
         this.has4Fields = has4Fields;
         this.fileName = fileName;
     }
 
-    //  ---------------- METHODS ----------------
+    /**
+     * Genera el archivo asociado a la instancia dentro del directorio de trabajo actual. Si el
+     * archivo ya existe se reutiliza.
+     *
+     * @return el objeto {@link File} correspondiente al archivo de reservas.
+     * @throws IOException si el archivo no puede crearse por permisos u otra incidencia de E/S.
+     */
     public File createFile() throws IOException {
         validateInputs();
 
@@ -36,6 +61,15 @@ public class ReservationAll {
         return createFileInternal(directory, fileName);
     }
 
+    /**
+     * Crea físicamente un archivo en el directorio indicado. Se expone como método privado para
+     * facilitar las pruebas unitarias y el reuso en otros contextos.
+     *
+     * @param directory directorio en el que se generará el archivo.
+     * @param fileName  nombre del archivo a crear.
+     * @return referencia al archivo solicitado.
+     * @throws IOException si el archivo no puede crearse.
+     */
     private static File createFileInternal(File directory, String fileName) throws IOException {
         File file = new File(directory, fileName);
 
@@ -54,6 +88,13 @@ public class ReservationAll {
         }
     }
 
+    /**
+     * Genera un archivo independiente por cada destino encontrado en el archivo maestro. Cada
+     * fichero incluirá únicamente las reservas que coinciden con dicho destino.
+     *
+     * @param field campo que se utilizará para discriminar los destinos (habitualmente {@link ReservationFields#DESTINATION}).
+     * @throws IOException si hay problemas al leer o escribir los archivos generados.
+     */
     public void createandFillFileByDestination(ReservationFields field) throws IOException {
         if (!has4Fields) {
             throw new IllegalStateException("La opción de crear archivos por destino requiere el destino.");
@@ -96,6 +137,14 @@ public class ReservationAll {
         }
     }
 
+    /**
+     * Obtiene los destinos únicos presentes en el archivo gestionado y agrupa sus registros
+     * asociados.
+     *
+     * @param field campo que se analizará para construir el índice.
+     * @return mapa donde la clave es el destino y el valor la lista de reservas asociadas.
+     * @throws IOException si ocurre un problema al leer el archivo maestro.
+     */
     private Map<String, List<String[]>> getUniqueDestinationsWithRecords(ReservationFields field) throws IOException {
         // Mapa destino -> reservas
         Map<String, List<String[]>> reservasPorDestino = new HashMap<>();
@@ -127,13 +176,24 @@ public class ReservationAll {
         }
     }
 
+    /**
+     * Verifica que los parámetros mínimos para trabajar con archivos de reserva están presentes.
+     * Lanza una excepción en caso contrario.
+     */
     private void validateInputs() {
         if (fileName == null || fileName.isBlank()) {
             throw new IllegalArgumentException("fileName no puede ser nulo o vacío.");
         }
     }
 
-    // Método para escribir encabezados
+    /**
+     * Escribe los encabezados proporcionados en el archivo de reservas. Solo se ejecuta si el
+     * archivo está vacío para evitar duplicar información.
+     *
+     * @param file    archivo sobre el que se escribirán los encabezados.
+     * @param headers lista de campos a registrar como cabecera.
+     * @throws IOException si ocurre un problema de escritura.
+     */
     public void writeHeaders(File file, ReservationFields... headers) throws IOException {
         boolean fileExists = file.exists() && file.length() > 0;
 
@@ -151,6 +211,11 @@ public class ReservationAll {
         }
     }
 
+    /**
+     * Solicita al usuario los datos de una reserva y los persiste en el archivo asociado a la
+     * instancia. El método se apoya en validaciones de formato para cada campo y muestra mensajes de
+     * confirmación o error según corresponda.
+     */
     public void writeReservation() {
         String error;
         String reservationDataSeat;
@@ -239,6 +304,10 @@ public class ReservationAll {
         }
     }
 
+    /**
+     * Pregunta al usuario cuántas reservas desea crear y repite el proceso de captura tantas veces
+     * como se haya indicado.
+     */
     public void pickHowManyRegisters() {
         SpinnerNumberModel model = new SpinnerNumberModel(
                 1,   // valor inicial
@@ -270,6 +339,12 @@ public class ReservationAll {
         }
     }
 
+    /**
+     * Muestra un informe en consola con el contenido del archivo de reservas. Opcionalmente puede
+     * recibir una clase para calcular estadísticas filtradas.
+     *
+     * @param reservationClass clase de reserva a filtrar (opcional).
+     */
     public void logguer(ReservationClass... reservationClass) {
         List<String[]> reservas = new ArrayList<>();
 
@@ -336,7 +411,13 @@ public class ReservationAll {
         System.out.println("\n🎯 Proceso completado con éxito");
     }
 
-    // Método estático que recibe un enum de país
+    /**
+     * Muestra por consola las reservas almacenadas en el archivo correspondiente al país indicado.
+     * Si el archivo no existe se informa de ello.
+     *
+     * @param country destino del que se desean listar las reservas.
+     * @throws IOException si ocurre un problema al acceder al archivo.
+     */
     public static void showReservationsByCountry(Destinations country) throws IOException {
         // 1. Construir nombre del archivo
         String fileName = buildFileName(country);
@@ -355,12 +436,22 @@ public class ReservationAll {
         reservationsByCountry.logguer();
     }
 
-    // Método auxiliar: arma el nombre con prefijo "reservas_"
+    /**
+     * Genera el nombre de archivo estandarizado para un destino concreto.
+     *
+     * @param country destino a convertir en nombre de archivo.
+     * @return nombre normalizado del archivo.
+     */
     private static String buildFileName(Destinations country) {
         String normalized = country.name().toLowerCase();  // enum a minúsculas
         return "reservas_" + normalized + ".txt";
     }
 
+    /**
+     * Proporciona una representación legible del estado interno, útil para depuración.
+     *
+     * @return cadena con el nombre del archivo y si gestiona destinos.
+     */
     @Override
     public String toString() {
         return "Reservation.ReservationAll{" +

--- a/Tarea-01/src/Reservation/ReservationClass.java
+++ b/Tarea-01/src/Reservation/ReservationClass.java
@@ -1,5 +1,8 @@
 package Reservation;
 
+/**
+ * Representa las clases de viaje disponibles al registrar una reserva.
+ */
 public enum ReservationClass {
     FIRST,
     BUSINESS,

--- a/Tarea-01/src/Reservation/ReservationFields.java
+++ b/Tarea-01/src/Reservation/ReservationFields.java
@@ -1,5 +1,9 @@
 package Reservation;
 
+/**
+ * Enumera los campos que componen un registro de reserva. Se emplea para mantener consistente el
+ * orden de los datos durante la lectura y escritura de archivos.
+ */
 public enum ReservationFields {
     SEAT_NUMBER,
     PASSENGER_NAME,

--- a/Tarea-01/src/Utils/Utils.java
+++ b/Tarea-01/src/Utils/Utils.java
@@ -1,6 +1,5 @@
 package Utils;
 
-
 import Reservation.ReservationFields;
 
 import java.io.*;
@@ -9,7 +8,19 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 
+/**
+ * Utilidades de propósito general que complementan el flujo principal de la aplicación. Incluye
+ * operaciones de formato de texto, validación de registros y procesamiento masivo de archivos de
+ * reservas.
+ */
 public class Utils {
+
+    /**
+     * Capitaliza cada palabra de la cadena recibida preservando los espacios simples entre ellas.
+     *
+     * @param text texto a transformar.
+     * @return el texto con cada palabra iniciando en mayúscula.
+     */
     public static String capitalizeWords(String text) {
         if (text == null || text.isBlank()) {
             return text;
@@ -24,6 +35,14 @@ public class Utils {
         return sb.toString().trim();
     }
 
+    /**
+     * Valida una colección de registros verificando tanto la cantidad de campos como las reglas
+     * específicas asociadas a cada columna.
+     *
+     * @param records             registros a revisar.
+     * @param expectedFieldsCount número de columnas esperadas por registro.
+     * @return {@code true} si todos los registros cumplen con las reglas de validación.
+     */
     public static boolean validateReservationRecords(List<String[]> records, int expectedFieldsCount) {
         ReservationFields[] reservationFields = ReservationFields.values();
 
@@ -60,6 +79,13 @@ public class Utils {
     }
 
 
+    /**
+     * Aplica reglas de validación específicas según el tipo de campo indicado.
+     *
+     * @param field            valor a validar.
+     * @param reservationField tipo de campo que determina la validación.
+     * @return {@code null} si el valor es válido o un mensaje descriptivo del error.
+     */
     public static String validateField(String field, ReservationFields reservationField) {
         if (field == null || field.trim().isEmpty()) {
             return "⚠️ El campo " + reservationField.name() + " no puede estar vacío.";
@@ -98,6 +124,14 @@ public class Utils {
         };
     }
 
+    /**
+     * Procesa un archivo de reservas existente, separando los registros válidos por destino y
+     * registrando en un log los fallos detectados.
+     *
+     * @param inputFile           archivo CSV que contiene las reservas a evaluar.
+     * @param expectedFieldsCount número de columnas que cada registro debería poseer.
+     * @throws IOException si ocurre un problema al leer el archivo o al escribir los resultados.
+     */
     public static void processReservationFile(
             File inputFile,
             int expectedFieldsCount
@@ -199,6 +233,13 @@ public class Utils {
     }
 
 
+    /**
+     * Registra un mensaje de error junto con el registro problemático en un archivo de log.
+     *
+     * @param logFile     archivo donde se almacenará el error.
+     * @param row         registro que provocó la incidencia.
+     * @param description detalle del error encontrado.
+     */
     private static void logError(File logFile, String[] row, String description) {
         try (FileWriter fw = new FileWriter(logFile, true)) {
             String timestamp = LocalDateTime.now(ZoneOffset.UTC)

--- a/docs/DOCUMENTACION_PROYECTO.md
+++ b/docs/DOCUMENTACION_PROYECTO.md
@@ -1,0 +1,207 @@
+# Documentación Completa del Gestor de Reservas Aéreas
+
+## 1. Introducción
+El objetivo del proyecto es ofrecer una herramienta ligera en Java para crear, validar y analizar
+reservas aéreas almacenadas en archivos CSV. El sistema combina interactividad mediante
+ventanas emergentes (Swing) con utilidades de procesamiento en lote para que tanto usuarios
+operativos como desarrolladores puedan manipular la información de manera confiable.
+
+Esta documentación centraliza todos los detalles relevantes del código, describe los flujos
+principales y aporta guías para extender o mantener la solución en el futuro.
+
+## 2. Arquitectura general
+La solución se compone de dos paquetes principales:
+
+- `Reservation`: alberga la lógica de dominio para crear archivos, capturar datos y generar
+  reportes de reservas.
+- `Utils`: contiene funciones auxiliares que brindan validaciones, formateo y procesamiento de
+  archivos.
+
+La estructura del proyecto en disco es la siguiente:
+
+```text
+Tarea-01/
+├── CHANGELOG.md
+├── CHANGELOG_EN.md
+├── LICENSE
+├── README.md
+├── README_EN.md
+├── docs/
+│   └── DOCUMENTACION_PROYECTO.md
+└── Tarea-01/
+    └── src/
+        ├── Reservation/
+        │   ├── Destinations.java
+        │   ├── Main.java
+        │   ├── ReservationAll.java
+        │   ├── ReservationClass.java
+        │   └── ReservationFields.java
+        └── Utils/
+            └── Utils.java
+```
+
+## 3. Componentes principales
+### 3.1 `Reservation.Main`
+Es el punto de entrada del programa. El método `main` conserva el flujo original solicitado en la práctica y ejecuta secuencialmente tres ejercicios:
+
+1. **Archivo base** (comentado) para crear un fichero simple con tres campos.
+2. **Escenario maestro** que genera `reservas_maestro.txt`, captura información mediante Swing, crea archivos por destino y muestra un log filtrado por clase.
+3. **Escenario de validación** que procesa `reservas_maestro_con_errores.txt` utilizando las utilidades de comprobación masiva.
+
+La inclusión directa de estos pasos dentro de `main` permite reproducir los ejercicios sin necesidad de navegar por métodos auxiliares.
+
+### 3.2 `Reservation.ReservationAll`
+Clase responsable de:
+
+- Crear archivos de reservas y escribir encabezados.
+- Capturar datos de nuevas reservas mediante cuadros de diálogo (`writeReservation`).
+- Preguntar al usuario cuántas reservas generar (`pickHowManyRegisters`).
+- Mostrar informes en consola (`logguer`).
+- Dividir el archivo maestro en subarchivos por destino (`createandFillFileByDestination`).
+- Mostrar reservas específicas de un destino (`showReservationsByCountry`).
+
+La clase admite dos modos:
+
+- **Tres campos**: asiento, pasajero y clase.
+- **Cuatro campos**: añade el destino, habilitando la segmentación por país.
+
+### 3.3 `Reservation.ReservationFields`
+Enumeración que define el orden y la semántica de los campos de un registro. Se utiliza en la
+creación de encabezados, validaciones y operaciones de agrupamiento.
+
+### 3.4 `Reservation.ReservationClass`
+Enumera las clases de viaje disponibles (First, Business y Economy). Se emplea tanto en la
+captura interactiva como en los reportes.
+
+### 3.5 `Reservation.Destinations`
+Catálogo predefinido de destinos soportados. Permite limitar la entrada de datos a una lista
+controlada y evita inconsistencias al generar archivos por país.
+
+### 3.6 `Utils.Utils`
+Proporciona utilidades de apoyo:
+
+- `capitalizeWords`: normaliza nombres y apellidos.
+- `validateReservationRecords` y `validateField`: reglas de validación para cada campo.
+- `processReservationFile`: lee un CSV existente, separa los registros válidos por destino y
+  genera un log con los errores.
+- Método privado `logError` para registrar incidencias con marca de tiempo.
+
+## 4. Flujo de datos
+### 4.1 Archivos involucrados
+- `reservas_maestro.txt`: archivo principal con encabezados y todas las reservas capturadas.
+- `reservas_<destino>.txt`: archivos secundarios generados automáticamente por destino.
+- `reservas_maestro_con_errores.txt`: archivo preparado manualmente con datos de prueba para
+  evaluar la validación.
+- `registro_errores.log`: resultado de procesar archivos con errores; contiene la descripción
+  detallada de cada incidencia.
+
+### 4.2 Captura interactiva
+1. El usuario ejecuta `java -cp out Reservation.Main`.
+2. Se crea (o reutiliza) el archivo maestro y sus encabezados.
+3. Aparece un cuadro de selección numérica para definir cuántas reservas ingresar.
+4. Para cada reserva se solicitan asiento, nombre, clase y destino. Cada entrada se valida al
+   momento y se muestra una notificación de éxito o error.
+5. Una vez finalizada la captura, el sistema genera automáticamente los archivos por destino y
+   muestra un log con un resumen.
+
+### 4.3 Procesamiento por destino
+`createandFillFileByDestination` agrupa las reservas del archivo maestro por país y genera
+un archivo individual para cada uno. Cada fichero incluye los encabezados y los registros
+correspondientes.
+
+### 4.4 Validación en lote
+`Utils.processReservationFile` permite revisar archivos externos o preparados con errores.
+El método detecta inconsistencias (campos vacíos, formatos incorrectos, cantidad de columnas) y
+las registra en `registro_errores.log`. Los registros válidos se guardan en archivos
+`reservas_<destino>.txt` sobrescribiendo cualquier contenido previo para garantizar coherencia.
+
+## 5. Guía de uso rápido
+### 5.1 Requisitos
+- JDK 17 o superior.
+- Entorno gráfico disponible para ejecutar Swing.
+
+### 5.2 Compilación
+Desde la carpeta `Tarea-01/Tarea-01`:
+
+```bash
+mkdir -p out
+javac -d out $(find src -name "*.java")
+```
+
+### 5.3 Ejecución de ejemplos
+- Ejecución completa de la práctica:
+  ```bash
+  java -cp out Reservation.Main
+  ```
+
+### 5.4 Validación de archivos existentes
+Asegúrate de colocar o editar `reservas_maestro_con_errores.txt` en la raíz del proyecto.
+Después ejecuta:
+
+```bash
+java -cp out Reservation.Main
+```
+
+El bloque final de `main` detectará que el archivo contiene datos y lanzará el proceso
+de validación.
+
+## 6. Validaciones y manejo de errores
+- **Número de asiento**: debe seguir el patrón `\d{1,3}[A-F]` (ejemplo: `12C`).
+- **Nombre del pasajero**: admite letras, espacios y caracteres acentuados.
+- **Clase**: se limita a `ECONOMY`, `BUSINESS` o `FIRST`.
+- **Destino**: mínimo tres caracteres; se recomienda usar valores del enum `Destinations`.
+
+Los mensajes de error se presentan tanto en los cuadros de diálogo como en consola durante el
+procesamiento en lote. `processReservationFile` además genera un log con marca temporal.
+
+## 7. Extensión y mantenimiento
+- **Añadir nuevos destinos**: incorporar el nombre en `Destinations.java`. El resto del flujo los
+  reconocerá automáticamente.
+- **Cambiar el formato de archivos**: modificar los métodos `writeHeaders`, `writeReservation` y
+  `processReservationFile` para ajustar el separador o los encabezados.
+- **Automatizar la captura**: sustituir las llamadas a `JOptionPane` por lectura de consola o por
+  integración con otras fuentes de datos.
+- **Pruebas unitarias**: los métodos están estructurados para facilitar la inyección de dependencias
+  y aislar la lógica. Por ejemplo, `createFileInternal` es `static` y puede probarse con directorios
+  temporales.
+
+## 8. Referencia rápida de clases y métodos
+| Clase                         | Responsabilidad principal                                      | Métodos clave |
+|------------------------------|----------------------------------------------------------------|---------------|
+| `Reservation.Main`           | Orquesta los ejemplos de uso y coordina los escenarios         | `main` |
+| `Reservation.ReservationAll` | Gestión integral de archivos de reservas                       | `createFile`, `writeHeaders`, `pickHowManyRegisters`, `logguer`, `createandFillFileByDestination`, `showReservationsByCountry` |
+| `Reservation.ReservationFields` | Define el orden y tipo de cada columna                      | Uso en validaciones y encabezados |
+| `Reservation.ReservationClass`  | Enum de clases disponibles                                  | Uso en capturas y filtros |
+| `Reservation.Destinations`      | Catálogo de destinos permitidos                             | Uso en menús y nombres de archivo |
+| `Utils.Utils`                   | Validaciones y utilidades de procesamiento                  | `capitalizeWords`, `validateField`, `processReservationFile` |
+
+## 9. Buenas prácticas adoptadas
+- JavaDoc detallado en todos los métodos para facilitar el mantenimiento.
+- Uso de enumeraciones para evitar cadenas mágicas y errores de tipeo.
+- Separación clara entre la lógica de dominio (`Reservation`) y las utilidades (`Utils`).
+- Logs descriptivos y mensajes de consola amigables para la persona usuaria.
+
+## 10. Preguntas frecuentes
+**¿Necesito interfaz gráfica para ejecutar el proyecto?**
+Sí. La captura de datos se realiza mediante `JOptionPane`, por lo que se requiere un entorno con soporte para Swing. Si necesitas automatizar la entrada, revisa la sección de extensiones para reemplazar los cuadros de diálogo.
+
+**¿Dónde se guardan los archivos generados?**
+En el mismo directorio donde se ejecuta la aplicación, habitualmente `Tarea-01/Tarea-01`.
+
+**¿Cómo limpio los archivos creados durante las pruebas?**
+Elimina los archivos `reservas_*.txt` y `registro_errores.log`. Se regenerarán según sea necesario.
+
+**¿Puedo cambiar el idioma de los mensajes?**
+Sí, basta con editar las cadenas de texto en las clases correspondientes. Se recomienda extraerlas
+ a un archivo de propiedades si se planea soportar múltiples idiomas.
+
+## 11. Próximos pasos sugeridos
+- Agregar pruebas automatizadas que simulen la captura de datos sin dependencia de Swing.
+- Incorporar persistencia en base de datos para entornos productivos.
+- Internacionalizar los mensajes para soportar otros idiomas.
+- Integrar una interfaz web o móvil como capa de presentación alternativa.
+
+---
+
+Esta documentación se mantendrá actualizada conforme evolucione el proyecto. Cualquier aporte o
+sugerencia es bienvenido mediante issues o pull requests.


### PR DESCRIPTION
## Summary
- revert Main.java to keep the original three-exercise flow while retaining contextual JavaDoc
- align the Spanish and English READMEs with the restored execution behavior
- refresh the extended documentation to describe the sequential examples in `main`

## Testing
- `cd Tarea-01 && mkdir -p out && javac -d out $(find src -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_b_68e1741f5e448320ac20fb7391ade43f